### PR TITLE
chore(renovate): fix matchBaseBranches to use existing master branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
         "major"
       ],
       "matchBaseBranches": [
-        "develop"
+        "master"
       ],
       "enabled": false
     }


### PR DESCRIPTION
The rule referenced a non-existent develop branch, causing Renovate to emit a config warning and rendering the major-update block ineffective.